### PR TITLE
feat(go): --enum-type-name-suffix to avoid same-package enum conflicts

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -237,7 +237,7 @@ export class GoRenderer extends ConvenienceRenderer {
         let columns: Sourcelike[][] = [];
         this.forEachEnumCase(e, "none", (name, jsonName) => {
             columns.push([
-                [name, " "],
+                this._options.enumTypeNameSuffix ? [name, enumName, " "] : [name, " "],
                 [enumName, ' = "', stringEscape(jsonName), '"']
             ]);
         });

--- a/packages/quicktype-core/src/language/Golang/language.ts
+++ b/packages/quicktype-core/src/language/Golang/language.ts
@@ -17,7 +17,8 @@ export const goOptions = {
         "omit-empty",
         'If set, all non-required objects will be tagged with ",omitempty"',
         false
-    )
+    ),
+    enumTypeNameSuffix: new BooleanOption("enum-type-name-suffix", "Appends the type name to enum contracts", false)
 };
 
 export class GoTargetLanguage extends TargetLanguage {
@@ -32,7 +33,8 @@ export class GoTargetLanguage extends TargetLanguage {
             goOptions.packageName,
             goOptions.multiFileOutput,
             goOptions.fieldTags,
-            goOptions.omitEmpty
+            goOptions.omitEmpty,
+            goOptions.enumTypeNameSuffix
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option that allows appending the associated type name to enumeration outputs.
  - Updated the formatting of enum case names in generated Go code based on this new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->