### PR TITLE
fix: Prevent reserved keywords in param names

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -11,7 +11,14 @@ import { type ClassProperty, type ClassType, type EnumType, type Type, type Type
 import { matchType, nullableFromUnion, removeNullFromUnion } from "../../TypeUtils";
 
 import { type goOptions } from "./language";
-import { canOmitEmpty, compoundTypeKinds, isValueType, namingFunction, primitiveValueTypeKinds } from "./utils";
+import {
+    canOmitEmpty,
+    compoundTypeKinds,
+    isValueType,
+    namingFunction,
+    primitiveValueTypeKinds,
+    reservedKeywords
+} from "./utils";
 
 export class GoRenderer extends ConvenienceRenderer {
     private readonly _topLevelUnmarshalNames = new Map<Name, Name>();
@@ -95,13 +102,20 @@ export class GoRenderer extends ConvenienceRenderer {
         if (!str) return str;
         return str.charAt(0).toLowerCase() + str.slice(1);
     }
+    
+    private validateParamName(name: string): string {
+        if (reservedKeywords.includes(name)) {
+            return name+"Value";
+        }
+        return name;
+    }
 
     private emitConstructor(name: Name, c: ClassType): void {
         this.ensureBlankLine();
         let structInitialisationRows: Sourcelike[][] = [];
         let ctorFunctionParameters: Sourcelike[][] = [];
         this.forEachClassProperty(c, "none", (name, _, p) => {
-            const parameterName = this.lowercaseFirstLetter(this.sourcelikeToString(name))
+            const parameterName = this.validateParamName(this.lowercaseFirstLetter(this.sourcelikeToString(name)));
             const goType = this.propertyGoType(p);
             ctorFunctionParameters.push([
                 parameterName,

--- a/packages/quicktype-core/src/language/Golang/utils.ts
+++ b/packages/quicktype-core/src/language/Golang/utils.ts
@@ -31,6 +31,34 @@ function goNameStyle(original: string): string {
 export const primitiveValueTypeKinds: TypeKind[] = ["integer", "double", "bool", "string"];
 export const compoundTypeKinds: TypeKind[] = ["array", "class", "map", "enum"];
 
+export const reservedKeywords: string[] = [
+    "break",
+    "default",
+    "func",
+    "interface",
+    "select",
+    "case",
+    "defer",
+    "go",
+    "map",
+    "struct",
+    "chan",
+    "else",
+    "goto",
+    "package",
+    "switch",
+    "const",
+    "fallthrough",
+    "if",
+    "range",
+    "type",
+    "continue",
+    "for",
+    "import",
+    "return",
+    "var"
+];
+
 export function isValueType(t: Type): boolean {
     const kind = t.kind;
     return primitiveValueTypeKinds.includes(kind) || kind === "class" || kind === "enum" || kind === "date-time";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Go code generation with improved handling of parameter names to automatically adjust any that conflict with reserved keywords.
  - Integrated a comprehensive set of reserved Go keywords, ensuring more robust and reliable generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->