### PR TITLE
add option for camel case field tag

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -254,9 +254,10 @@ export class GoRenderer extends ConvenienceRenderer {
             const omitEmpty = canOmitEmpty(p, this._options.omitEmpty) ? ",omitempty" : [];
 
             docStrings.forEach(doc => columns.push([doc]));
+            const fieldTagName = this._options.useCamelCaseFieldTags ? camelCase(jsonName) : jsonName;
             const tags = this._options.fieldTags
                 .split(",")
-                .map(tag => tag + ':"' + stringEscape(jsonName) + omitEmpty + '"')
+                .map(tag => tag + ':"' + stringEscape(fieldTagName) + omitEmpty + '"')
                 .join(" ");
             columns.push([
                 [name, " "],

--- a/packages/quicktype-core/src/language/Golang/language.ts
+++ b/packages/quicktype-core/src/language/Golang/language.ts
@@ -20,6 +20,7 @@ export const goOptions = {
     ),
     enumTypeNameSuffix: new BooleanOption("enum-type-name-suffix", "Appends the type name to enum contracts", false),
     includeConstructors: new BooleanOption("include-constructors", "Adds a constructor for each struct type", false),
+    useCamelCaseFieldTags: new BooleanOption("camel-case-field-tags", "Uses camel case field tags", false)
 };
 
 export class GoTargetLanguage extends TargetLanguage {
@@ -37,6 +38,7 @@ export class GoTargetLanguage extends TargetLanguage {
             goOptions.omitEmpty,
             goOptions.enumTypeNameSuffix,
             goOptions.includeConstructors,
+            goOptions.useCamelCaseFieldTags
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to use camelCase field tags when generating Go struct fields. Users can now enable camelCase formatting for field tags in generated Go code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->